### PR TITLE
Fix wrong import in example of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage
 package main
 
 import (
-	"glog"
+	"github.com/golang/glog"
 
 	"github.com/devsisters/cine"
 )


### PR DESCRIPTION
Fixed wrong import of 'glog' in phonebook example of README.md.
